### PR TITLE
int64 don't work on 32-bit arch cpu. This fix compensates for int64 unavailability

### DIFF
--- a/src/Engine/Decoder.php
+++ b/src/Engine/Decoder.php
@@ -111,9 +111,15 @@ final class Decoder
         }
 
         $int = (int)$intStr;
+        
 
         if ((string)$int !== $intStr) {
-            throw new ParseErrorException("Invalid integer format or integer overflow: '{$intStr}'");
+            
+            $int = (double)$intStr;
+            
+            if ((string)$int !== $intStr) {
+                throw new ParseErrorException("Invalid integer format or integer overflow: '{$intStr} !== {$int}'");
+            }
         }
 
         $this->finalizeScalar($int);


### PR DESCRIPTION
For test decode "i9012914924e". In 32-bit php, where PHP_MAX_INT = 2147483647 this call:
Fatal error: Uncaught SandFox\Bencode\Exceptions\ParseErrorException: Invalid integer format or integer overflow: '9012914924' in /ww/src/SandFox/Bencode/Engine/Decoder.php:116
This fix help for it